### PR TITLE
Stroke Text - Align property

### DIFF
--- a/lib/src/text_with_border.dart
+++ b/lib/src/text_with_border.dart
@@ -47,6 +47,7 @@ class StrokeText extends StatelessWidget {
         Text(
           text,
           style: TextStyle(color: textColor).merge(textStyle),
+          textAlign: textAlign,
           textDirection: textDirection,
           textScaler: textScaler,
           overflow: overflow,


### PR DESCRIPTION

This prevents aligning from only applying to the border.